### PR TITLE
fix(prometheus): Initialize known labels to 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,14 @@ func run(conf configuration, listen string, debug bool) {
 		ag.enableDebug()
 	}
 
+	// Initialize known prometheus labels to 0
+	for _, authorization := range conf.Authorizations {
+		for _, signer := range authorization.Signers {
+			signerRequestsCounter.WithLabelValues(signer, authorization.ID, "false")
+			signerRequestsCounter.WithLabelValues(signer, authorization.ID, "true")
+		}
+	}
+
 	ag.startCleanupHandler()
 
 	// Initialize a monitor.


### PR DESCRIPTION
- **chore(deps): AUT-189 Update pkcs7 and enable race CI test (#972)**
- **build(deps): bump golang.org/x/crypto (#974)**
- **upgrade cloudhsm-cleanup tools to AWS CloudHSM v5 (#973)**
- **feat(dependabot): Enable Dependabot version updates (#971)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2 from 1.30.3 to 1.30.5 (#979)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2/feature/s3/manager (#978)**
- **emit request URI in signature handler response log (#976)**
- **build(deps): bump golang.org/x/net (#975)**
- **AUT-184: install Google's libkmsp11 into autograph docker image (#983)**
- **AUT-228 - Fixing monitor errors in stage (#981)**
- **remove verifier replace statement in go.mod (#986)**
- **AUT-252: fork crypto11 into the autograph repository (#984)**
- **AUT-250 - Getting deploy pipeline for autograph-monitor fixed (#985)**
- **AUT-250 - Missed that the deploy step also ran on merges to main. Moving monitor zip build to seperate workflow (#988)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2/service/s3 (#996)**
- **feat: remove GetPrivKeyHandle (#992)**
- **Improving autograph monitor log messages (#991)**
- **correct CheckHSMConnection error handling (#1000)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2 from 1.30.5 to 1.31.0 (#1003)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2/feature/s3/manager (#999)**
- **refactor: isolate HSM interactions and crypto11 use in a more generic interface (#993)**
- **clean up main.initHSM error handling (#1004)**
- **add goimports to the linter (#1005)**
- **Adjustments to android-store scripts (#990)**
- **add tests for the new hsm interface (#1007)**
- **AUT-201 - make autograph monitor work in GCP (#1006)**
- **AUT-252: add new public functions to crypto11 that allow us to generate keys with libkmsp11 (#987)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2/config (#1011)**
- **build(deps): bump github.com/aws/aws-sdk-go-v2 from 1.31.0 to 1.32.0 (#1015)**
- **feat: support GCP KMS in makecsr tools (#1019)**
- **dependabot: group AWS SDK version bumps into one PR (#1013)**
- **bundle top-level aws-sdk-go-v2 in dependabot group (#1022)**
- **build(deps): bump the aws-sdk-go-v2 group across 1 directory with 4 updates (#1024)**
- **AUT-272 - Making monitor handler more informative (#1008)**
- **Use the same rand in SignHash method (#1023)**
- **Explicitly state DOCKER_DEFAULT_PLATFORM (#1025)**
- **Revert to rand reader instead of ContentSigner rand (#1028)**
- **remove make-hsm-ee tool (#1027)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1031)**
- **crypto11: handle nil returns from pcks11.New (#1034)**
- **AUT-251 Use the same rand on SignHash as the ContentSigner (#1033)**
- **Optimizing dockerfile for caching. This way if code changes, we don't have to re-pull dependencies. (#1035)**
- **remove executable bit from some source files (#1039)**
- **fix: workflow name for autograph monitor build (#1036)**
- **build(deps): bump the aws-sdk-go-v2 group with 2 updates (#1038)**
- **refresh makecsr and add it to the Dockerfile (#1030)**
- **monitor: make monitor testable (#1040)**
- **AUT-313: break up too-large-for-GCP random reads before sending them to libkmsp11 (#1032)**
- **build(deps): bump the aws-sdk-go-v2 group with 3 updates (#1041)**
- **build(deps): bump go.uber.org/mock from 0.4.0 to 0.5.0 (#1042)**
- **correct makecsr README's example libkmsp11 config (#1043)**
- **Adding libengine-pkcs11-openssl package to container. (#1044)**
- **use local random generator in GCP (#1047)**
- **monitor: add the gcp dev environment (#1048)**
- **build(deps): bump the aws-sdk-go-v2 group with 2 updates (#1049)**
- **AUT-270: implement new deployment workflow for autograph (#1037)**
- **use crane to exactly copy our image during deploy (#1050)**
- **fix: replace setup-crane step with copypasta (#1051)**
- **upgrade github.com/sirupsen/logrus to v1.9.3 (#1053)**
- **upgrade github.com/lib/pq to v1.10.9 (#1054)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1055)**
- **Add Makefile commands to run docker container interactively for dev work (#1045)**
- **remove statsd client set up from signer/xpi.TestSignFile (#1057)**
- **monitor: be more lenient and more strict about AUTOGRAPH_URL (#1012)**
- **build our docker images for multiple platforms (#1059)**
- **stop creating tags of the sha256 of the image (#1060)**
- **correct our CMD in the main Dockerfile (#1061)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1064)**
- **AUT-350 - Adding more database permissions for unit test database container. (#1058)**
- **correct the docker pushes (#1063)**
- **build(deps): bump the aws-sdk-go-v2 group with 3 updates (#1067)**
- **add docker to dependabot (#1066)**
- **build(deps): bump postgres from 14 to 17 in /database (#1068)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1069)**
- **migrate to golang:bookworm image (#1070)**
- **build(deps): bump golang from 1.22.1-bookworm to 1.23.4-bookworm (#1075)**
- **build(deps): bump the aws-sdk-go-v2 group across 1 directory with 4 updates (#1077)**
- **upgrade github.com/DataDog/datadog-go to v4.8.3+incompatible from v3.7.2+incompatible (#1076)**
- **count signer requests with some useful tags (#1078)**
- **AUT-371 - Removing cleanup step and sleep from endentities testing. (#1081)**
- **add the post-cert-succession root to the monitor (#1082)**
- **monitor: add ability to ignore expiration of signer ids (#1084)**
- **monitor: remove the unneeded conf.env field (#1083)**
- **upgrade sops from v3.4.0 to v3.5.0 (#1062)**
- **build(deps): bump golang.org/x/crypto from 0.21.0 to 0.31.0 (#1085)**
- **bump Go min version to 1.23.4 (#1079)**
- **Note discrepancy between local and CI integration tests (#1026)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1088)**
- **Adding more details to makecsr docs with a very practical example (#1086)**
- **build(deps): bump the aws-sdk-go-v2 group with 2 updates (#1089)**
- **upgrade sops to v3.9.3 from v3.5.0 (#1087)**
- **AUT-291 - expanding makecsr options (#1090)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1091)**
- **migrate to github.com/DataDog/datadog-go/v5/statsd (#1080)**
- **add prometheus and counter for testing (#1092)**
- **add prom-only test counter and statsd-only label (#1094)**
- **add direct-to-prometheus metric for signer requests (#1095)**
- **delay test metrics by some minutes (#1096)**
- **migrate to go.uber.org/gomock (#1093)**
- **correct signer_requests prometheus metric (#1099)**
- **move profilers to debug server (#1098)**
- **build(deps): bump golang from 1.23.4-bookworm to 1.23.5-bookworm (#1100)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1101)**
- **AUT-199 - Replacing statsd with prometheus. First pass. (#1102)**
- **build(deps): bump github.com/golang/glog from 1.2.2 to 1.2.4 (#1105)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1103)**
- **build(deps): bump github.com/getsops/sops/v3 from 3.9.3 to 3.9.4 (#1104)**
- **AUT-199 - Adding quantile objectives to signer request timing metric. (#1106)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1107)**
- **build(deps): bump golang from 1.23.5-bookworm to 1.23.6-bookworm (#1109)**
- **build(deps): bump the aws-sdk-go-v2 group with 4 updates (#1108)**
- **Fixing our unit tests with the expired cert. (#1113)**
- **build(deps): bump the aws-sdk-go-v2 group across 1 directory with 4 updates (#1114)**
- **build(deps): bump golang from 1.23.6-bookworm to 1.24.0-bookworm (#1110)**
- **Fix unit tests command in README (#1112)**
- **build(deps): bump github.com/prometheus/client_golang (#1116)**
- **build(deps): bump github.com/go-jose/go-jose/v4 from 4.0.4 to 4.0.5 (#1117)**
- **fix(prometheus): Initialize known labels to 0**
